### PR TITLE
Add support for GNOME 42 (Ubuntu 22.04)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"localedir": "/usr/local/share/locale",
 	"shell-version": [
-		  "3.28", "3.36", "3.38", "40"
+		  "3.28", "3.36", "3.38", "40", "42"
 	],
 	"uuid": "cpupower@mko-sl.de",
 	"name": "CPU Power Manager",


### PR DESCRIPTION
Ensure that GNOME 42 is supported. This also adds support for Ubuntu 22.04, which includes GNOME 42 out of the box.